### PR TITLE
feat: add basic chat service

### DIFF
--- a/src/services/chat.ts
+++ b/src/services/chat.ts
@@ -1,0 +1,34 @@
+import { http, httpStream } from './http';
+
+export interface Chat {
+  [key: string]: any;
+}
+
+export const chatService = {
+  async startChat(options: Chat, onChunk: (step: string, data: any) => void) {
+    await httpStream(
+      '/chat',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(options),
+      },
+      (event) => {
+        const { step, data } = event;
+        onChunk(step, data);
+      },
+    );
+  },
+
+  async getChat(id: string) {
+    return 'TODO';
+  },
+
+  async startTask(id: string) {
+    return 'TODO';
+  },
+
+  async validateModel(data: any) {
+    return 'TODO';
+  },
+};

--- a/src/services/http.ts
+++ b/src/services/http.ts
@@ -1,0 +1,57 @@
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '';
+
+function buildUrl(path: string): string {
+  if (path.startsWith('http')) {
+    return path;
+  }
+  const base = API_BASE_URL.replace(/\/$/, '');
+  return `${base}${path}`;
+}
+
+export async function http<T>(path: string, init: RequestInit = {}): Promise<T> {
+  const url = buildUrl(path);
+  const response = await fetch(url, init);
+  if (!response.ok) {
+    const message = await response.text();
+    throw new Error(message || response.statusText);
+  }
+  const contentType = response.headers.get('content-type') || '';
+  if (contentType.includes('application/json')) {
+    return (await response.json()) as T;
+  }
+  return (await response.text()) as unknown as T;
+}
+
+export async function httpStream(
+  path: string,
+  init: RequestInit = {},
+  onMessage: (event: any) => void,
+): Promise<void> {
+  const url = buildUrl(path);
+  const response = await fetch(url, init);
+  if (!response.ok || !response.body) {
+    const message = await response.text();
+    throw new Error(message || response.statusText);
+  }
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    const parts = buffer.split('\n\n');
+    buffer = parts.pop() || '';
+    for (const part of parts) {
+      const line = part.trim();
+      if (!line.startsWith('data:')) continue;
+      const payload = line.slice(5).trim();
+      if (payload === '[DONE]') return;
+      try {
+        onMessage(JSON.parse(payload));
+      } catch (e) {
+        console.error('Failed to parse SSE payload', e);
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add HTTP utility with base URL and SSE stream parsing
- implement chatService with startChat stream support
- stub TODO endpoints for future chat and model APIs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad79b9afb08328b70550e70eded7cd