### PR TITLE
feat: enhance chat controls

### DIFF
--- a/src/services/chat.ts
+++ b/src/services/chat.ts
@@ -20,6 +20,30 @@ export const chatService = {
     );
   },
 
+  async supplement(id: string, question: string) {
+    await http(`/chat/${id}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ question }),
+    });
+  },
+
+  async takeControl(id: string, action: 'pause' | 'resume') {
+    await http(`/task/${id}/take-control`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ action }),
+    });
+  },
+
+  async humanReply(id: string, agent: string, reply: string) {
+    await http(`/chat/${id}/human-reply`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ agent, reply }),
+    });
+  },
+
   async getChat(id: string) {
     return 'TODO';
   },


### PR DESCRIPTION
## Summary
- add supplement and pause/resume controls in chat page
- support human replies and handle new SSE events

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad7bc17ae48328b6ffbf1c4dae26b0