### PR TITLE
feat(frontend): add chat attachments and agent indicators

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^7.6.0"
+    "react-router-dom": "^7.6.0",
+    "lucide-react": "^0.509.0"
   },
   "devDependencies": {
     "@types/react": "^18.3.12",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,9 +1,13 @@
-import { Routes, Route } from 'react-router-dom'
+import { Routes, Route, Navigate } from 'react-router-dom'
+import Config from './pages/Config'
+import Chat from './pages/Chat'
 
 function App() {
   return (
     <Routes>
-      <Route path="/" element={<h1 className="text-2xl font-bold">Hello Vite + React!</h1>} />
+      <Route path="/" element={<Navigate to="/config" replace />} />
+      <Route path="/config" element={<Config />} />
+      <Route path="/chat" element={<Chat />} />
     </Routes>
   )
 }

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -1,0 +1,170 @@
+import { useState } from 'react';
+import { CodeXml, Globe, FileText, Image as ImageIcon } from 'lucide-react';
+import { chatService } from '../services/chat';
+
+interface AgentState {
+  icon: JSX.Element;
+  active: boolean;
+  logs: string[];
+}
+
+const defaultAgents: Record<string, AgentState> = {
+  developer_agent: { icon: <CodeXml size={16} />, active: false, logs: [] },
+  search_agent: { icon: <Globe size={16} />, active: false, logs: [] },
+  new_search_agent: { icon: <Globe size={16} />, active: false, logs: [] },
+  document_agent: { icon: <FileText size={16} />, active: false, logs: [] },
+  multi_modal_agent: { icon: <ImageIcon size={16} />, active: false, logs: [] },
+};
+
+export default function Chat() {
+  const [taskId] = useState(() => Date.now().toString());
+  const [message, setMessage] = useState('');
+  const [files, setFiles] = useState<{ file: File; path?: string }[]>([]);
+  const [agents, setAgents] = useState(defaultAgents);
+
+  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const selected = e.target.files;
+    if (!selected) return;
+    const uploads: { file: File; path?: string }[] = [];
+    for (const file of Array.from(selected)) {
+      try {
+        const res = await chatService.uploadAttachment(file, taskId);
+        const path = res?.url || res?.path || res?.file_path || '';
+        uploads.push({ file, path });
+      } catch (err) {
+        console.error('upload failed', err);
+      }
+    }
+    setFiles((prev) => [...prev, ...uploads]);
+    e.target.value = '';
+  };
+
+  const removeFile = (name: string) => {
+    setFiles((prev) => prev.filter((f) => f.file.name !== name));
+  };
+
+  const handleSend = async () => {
+    if (!message.trim()) return;
+    const config = JSON.parse(localStorage.getItem('config') || '{}');
+    const options = {
+      task_id: taskId,
+      question: message,
+      email: config.email || '',
+      api_key: config.api_key || '',
+      model_platform: config.model_platform || '',
+      model_type: config.model_type || '',
+      attaches: files.map((f) => f.path).filter(Boolean),
+    };
+    setMessage('');
+    try {
+      await chatService.startChat(options, (step, data) => {
+        const id = data?.agent_id || data?.agent_name;
+        const log = data?.message || data?.content || data?.result || '';
+        if (step === 'activate_agent' && id) {
+          setAgents((prev) => ({
+            ...prev,
+            [id]: {
+              ...(prev[id] || { icon: <CodeXml size={16} />, logs: [] }),
+              active: true,
+              logs: log ? [...(prev[id]?.logs || []), log] : prev[id]?.logs || [],
+            },
+          }));
+        } else if (step === 'deactivate_agent' && id) {
+          setAgents((prev) => ({
+            ...prev,
+            [id]: {
+              ...(prev[id] || { icon: <CodeXml size={16} />, logs: [] }),
+              active: false,
+              logs: log ? [...(prev[id]?.logs || []), log] : prev[id]?.logs || [],
+            },
+          }));
+        } else if (id && log) {
+          setAgents((prev) => ({
+            ...prev,
+            [id]: {
+              ...(prev[id] || { icon: <CodeXml size={16} />, active: false, logs: [] }),
+              logs: [...(prev[id]?.logs || []), log],
+            },
+          }));
+        }
+      });
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <div className="flex gap-4">
+        {Object.entries(agents).map(([key, info]) => (
+          <div key={key} className="flex flex-col items-center text-xs">
+            <div className={info.active ? 'text-blue-600' : 'text-gray-400'}>{info.icon}</div>
+            <span className="mt-1">{key.replace(/_/g, ' ')}</span>
+          </div>
+        ))}
+      </div>
+
+      <div>
+        {Object.entries(agents).map(([key, info]) => (
+          info.logs.length > 0 && (
+            <div key={key} className="mb-2">
+              <div className="font-semibold mb-1">{key.replace(/_/g, ' ')}</div>
+              <ul className="list-disc ml-5 text-sm space-y-1">
+                {info.logs.map((log, i) => (
+                  <li key={i}>{log}</li>
+                ))}
+              </ul>
+            </div>
+          )
+        ))}
+      </div>
+
+      <div className="space-y-2">
+        <textarea
+          className="w-full border p-2"
+          rows={3}
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+          placeholder="Ask something..."
+        />
+        <div className="flex items-center gap-2">
+          <input id="file" type="file" multiple className="hidden" onChange={handleFileChange} />
+          <label htmlFor="file" className="px-2 py-1 border rounded cursor-pointer">
+            Attach
+          </label>
+          <button
+            onClick={handleSend}
+            className="px-4 py-1 bg-blue-500 text-white rounded"
+          >
+            Send
+          </button>
+        </div>
+        {files.length > 0 && (
+          <ul className="mt-2 space-y-1 text-sm">
+            {files.map((f) => (
+              <li key={f.file.name} className="flex items-center gap-2">
+                {['jpg', 'jpeg', 'png', 'gif', 'bmp', 'svg'].includes(
+                  f.file.name.split('.').pop()?.toLowerCase() || '',
+                ) ? (
+                  <ImageIcon size={16} />
+                ) : (
+                  <FileText size={16} />
+                )}
+                <span className="flex-1 truncate" title={f.file.name}>
+                  {f.file.name}
+                </span>
+                <button
+                  onClick={() => removeFile(f.file.name)}
+                  className="text-red-500"
+                >
+                  x
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}
+

--- a/frontend/src/pages/Config.tsx
+++ b/frontend/src/pages/Config.tsx
@@ -1,0 +1,61 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+export default function Config() {
+  const navigate = useNavigate();
+  const [form, setForm] = useState(() => {
+    const saved = localStorage.getItem('config');
+    return saved ? JSON.parse(saved) : { email: '', api_key: '', model_platform: '', model_type: '' };
+  });
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setForm((prev: any) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    localStorage.setItem('config', JSON.stringify(form));
+    navigate('/chat');
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-xl font-bold">Config</h1>
+      <form onSubmit={handleSubmit} className="space-y-3">
+        <input
+          name="email"
+          value={form.email}
+          onChange={handleChange}
+          placeholder="email"
+          className="border p-2 w-full"
+        />
+        <input
+          name="api_key"
+          value={form.api_key}
+          onChange={handleChange}
+          placeholder="api_key"
+          className="border p-2 w-full"
+        />
+        <input
+          name="model_platform"
+          value={form.model_platform}
+          onChange={handleChange}
+          placeholder="model_platform"
+          className="border p-2 w-full"
+        />
+        <input
+          name="model_type"
+          value={form.model_type}
+          onChange={handleChange}
+          placeholder="model_type"
+          className="border p-2 w-full"
+        />
+        <button type="submit" className="px-4 py-2 bg-blue-500 text-white rounded">
+          Save
+        </button>
+      </form>
+    </div>
+  );
+}
+

--- a/frontend/src/services/chat.ts
+++ b/frontend/src/services/chat.ts
@@ -1,0 +1,63 @@
+import { http, httpStream, uploadFile } from './http';
+
+export interface Chat {
+  [key: string]: any;
+}
+
+export const chatService = {
+  async startChat(options: Chat, onChunk: (step: string, data: any) => void) {
+    await httpStream(
+      '/chat',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(options),
+      },
+      (event) => {
+        const { step, data } = event;
+        onChunk(step, data);
+      },
+    );
+  },
+
+  async uploadAttachment(file: File, taskId: string) {
+    return uploadFile('/chat/files/upload', file, taskId);
+  },
+
+  async supplement(id: string, question: string) {
+    await http(`/chat/${id}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ question }),
+    });
+  },
+
+  async takeControl(id: string, action: 'pause' | 'resume') {
+    await http(`/task/${id}/take-control`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ action }),
+    });
+  },
+
+  async humanReply(id: string, agent: string, reply: string) {
+    await http(`/chat/${id}/human-reply`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ agent, reply }),
+    });
+  },
+
+  async getChat(id: string) {
+    return 'TODO';
+  },
+
+  async startTask(id: string) {
+    return 'TODO';
+  },
+
+  async validateModel(data: any) {
+    return 'TODO';
+  },
+};
+

--- a/frontend/src/services/http.ts
+++ b/frontend/src/services/http.ts
@@ -1,0 +1,74 @@
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '';
+
+function buildUrl(path: string): string {
+  if (path.startsWith('http')) {
+    return path;
+  }
+  const base = API_BASE_URL.replace(/\/$/, '');
+  return `${base}${path}`;
+}
+
+export async function http<T>(path: string, init: RequestInit = {}): Promise<T> {
+  const url = buildUrl(path);
+  const response = await fetch(url, init);
+  if (!response.ok) {
+    const message = await response.text();
+    throw new Error(message || response.statusText);
+  }
+  const contentType = response.headers.get('content-type') || '';
+  if (contentType.includes('application/json')) {
+    return (await response.json()) as T;
+  }
+  return (await response.text()) as unknown as T;
+}
+
+export async function httpStream(
+  path: string,
+  init: RequestInit = {},
+  onMessage: (event: any) => void,
+): Promise<void> {
+  const url = buildUrl(path);
+  const response = await fetch(url, init);
+  if (!response.ok || !response.body) {
+    const message = await response.text();
+    throw new Error(message || response.statusText);
+  }
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    const parts = buffer.split('\n\n');
+    buffer = parts.pop() || '';
+    for (const part of parts) {
+      const line = part.trim();
+      if (!line.startsWith('data:')) continue;
+      const payload = line.slice(5).trim();
+      if (payload === '[DONE]') return;
+      try {
+        onMessage(JSON.parse(payload));
+      } catch (e) {
+        console.error('Failed to parse SSE payload', e);
+      }
+    }
+  }
+}
+
+export async function uploadFile(path: string, file: File, taskId: string) {
+  const url = buildUrl(path);
+  const formData = new FormData();
+  formData.append('file', file);
+  formData.append('task_id', taskId);
+  const response = await fetch(url, {
+    method: 'POST',
+    body: formData,
+  });
+  if (!response.ok) {
+    const message = await response.text();
+    throw new Error(message || response.statusText);
+  }
+  return response.json();
+}
+

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
## Summary
- add basic config and chat pages
- support file attachments with upload helper
- show default agent icons and log activity during chats

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad6eacc5188328aeb8998281fad7e4