### PR TITLE
feat(frontend): improve chat interface with sse events

### DIFF
--- a/frontend/src/components/AgentList.tsx
+++ b/frontend/src/components/AgentList.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+interface AgentState {
+  icon: JSX.Element;
+  active: boolean;
+}
+
+interface AgentListProps {
+  agents: Record<string, AgentState>;
+}
+
+export default function AgentList({ agents }: AgentListProps) {
+  return (
+    <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-5 gap-4">
+      {Object.entries(agents).map(([key, info]) => (
+        <div key={key} className="flex flex-col items-center text-xs">
+          <div
+            className={
+              'p-2 rounded-full ' +
+              (info.active
+                ? 'text-blue-600 bg-blue-50'
+                : 'text-gray-400 bg-gray-100')
+            }
+          >
+            {info.icon}
+          </div>
+          <span className="mt-1 text-center capitalize">
+            {key.replace(/_/g, ' ')}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+

--- a/frontend/src/components/AgentLogs.tsx
+++ b/frontend/src/components/AgentLogs.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+
+interface AgentInfo {
+  logs: string[];
+}
+
+interface AgentLogsProps {
+  agents: Record<string, AgentInfo>;
+}
+
+export default function AgentLogs({ agents }: AgentLogsProps) {
+  return (
+    <div className="space-y-4">
+      {Object.entries(agents).map(([key, info]) => (
+        info.logs.length > 0 && (
+          <div key={key} className="mb-2">
+            <div className="font-semibold mb-1 capitalize">
+              {key.replace(/_/g, ' ')}
+            </div>
+            <ul className="list-disc ml-5 text-sm space-y-1">
+              {info.logs.map((log, i) => (
+                <li key={i}>{log}</li>
+              ))}
+            </ul>
+          </div>
+        )
+      ))}
+    </div>
+  );
+}
+

--- a/frontend/src/components/ChatInput.tsx
+++ b/frontend/src/components/ChatInput.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { FileText, Image as ImageIcon } from 'lucide-react';
+
+interface UploadFile {
+  file: File;
+  path?: string;
+}
+
+interface ChatInputProps {
+  message: string;
+  files: UploadFile[];
+  onMessageChange: (val: string) => void;
+  onSend: () => void;
+  onFiles: (files: FileList) => void;
+  onRemoveFile: (name: string) => void;
+}
+
+export default function ChatInput({
+  message,
+  files,
+  onMessageChange,
+  onSend,
+  onFiles,
+  onRemoveFile,
+}: ChatInputProps) {
+  return (
+    <div className="space-y-2">
+      <textarea
+        className="w-full border p-2 rounded"
+        rows={3}
+        value={message}
+        onChange={(e) => onMessageChange(e.target.value)}
+        placeholder="Ask something..."
+      />
+      <div className="flex items-center gap-2">
+        <input
+          id="file-upload"
+          type="file"
+          multiple
+          className="hidden"
+          onChange={(e) => {
+            if (e.target.files) onFiles(e.target.files);
+          }}
+        />
+        <label
+          htmlFor="file-upload"
+          className="px-3 py-1 border rounded cursor-pointer"
+        >
+          Attach
+        </label>
+        <button
+          onClick={onSend}
+          className="px-4 py-1 bg-blue-500 text-white rounded"
+        >
+          Send
+        </button>
+      </div>
+      {files.length > 0 && (
+        <ul className="mt-2 space-y-1 text-sm">
+          {files.map((f) => (
+            <li key={f.file.name} className="flex items-center gap-2">
+              {['jpg', 'jpeg', 'png', 'gif', 'bmp', 'svg'].includes(
+                f.file.name.split('.').pop()?.toLowerCase() || '',
+              ) ? (
+                <ImageIcon size={16} />
+              ) : (
+                <FileText size={16} />
+              )}
+              <span className="flex-1 truncate" title={f.file.name}>
+                {f.file.name}
+              </span>
+              <button
+                onClick={() => onRemoveFile(f.file.name)}
+                className="text-red-500"
+              >
+                x
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+

--- a/frontend/src/components/StreamLog.tsx
+++ b/frontend/src/components/StreamLog.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+
+interface LogItem {
+  step: string;
+  data: any;
+}
+
+function renderData(step: string, data: any) {
+  if (!data) return null;
+  if (step === 'terminal') {
+    const output = data.output || data;
+    return (
+      <pre className="bg-black text-green-400 p-2 rounded whitespace-pre-wrap">
+        {output}
+      </pre>
+    );
+  }
+  if (typeof data === 'string') return <span>{data}</span>;
+  if (data.message) return <span>{data.message}</span>;
+  if (data.notice) return <span>{data.notice}</span>;
+  if (data.question) return <span>{data.question}</span>;
+  return <span>{JSON.stringify(data)}</span>;
+}
+
+interface StreamLogProps {
+  logs: LogItem[];
+}
+
+export default function StreamLog({ logs }: StreamLogProps) {
+  return (
+    <div className="bg-gray-50 p-4 rounded h-64 overflow-y-auto space-y-2">
+      {logs.map((log, i) => (
+        <div key={i} className="text-sm">
+          <span className="font-semibold mr-2">{log.step}</span>
+          {renderData(log.step, log.data)}
+        </div>
+      ))}
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- enhance chat page to stream backend SSE events and display agent activity
- add reusable UI components for agents, logs, event feed, and chat input

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ae56d063d883288143720d24455b29